### PR TITLE
add version to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/codingcyclist/ha_strava",
   "requirements": ["aiohttp==3.6.1", "voluptuous==0.11.7"],
   "dependencies": [],
+  "version": "0.1.1",
   "codeowners": ["@codingcyclist"]
 }


### PR DESCRIPTION
To support for HA 2021.06 release, requires "version" to be defined in manifest.json.