### PR TITLE
Remove EVENT_TIME_CHANGED const

### DIFF
--- a/custom_components/ha_strava/__init__.py
+++ b/custom_components/ha_strava/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_CORE_CONFIG_UPDATE,
     EVENT_HOMEASSISTANT_START,
-    EVENT_TIME_CHANGED,
 )
 from homeassistant.helpers import (
     aiohttp_client,

--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -17,7 +17,6 @@ from .const import (
     CONFIG_URL_DUMP_FILENAME,
 )
 from hashlib import md5
-from homeassistant.const import EVENT_TIME_CHANGED
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Hi,

With HA 2022.5.X, the EVENT_TIME_CHANGED constant was removed, see https://developers.home-assistant.io/blog/2022/04/20/saying-goodbye-to-event_time_changed.

This PR removes this event.

This fixes https://github.com/codingcyclist/ha_strava/issues/45